### PR TITLE
Added gcc/clang compatibility layer for coroutines

### DIFF
--- a/include/sqe_awaitable.hpp
+++ b/include/sqe_awaitable.hpp
@@ -1,19 +1,12 @@
 #pragma once
-#if __has_include(<coroutine>)
-#   include <coroutine>
-namespace std::experimental {
-    using std::suspend_always;
-    using std::suspend_never;
-    using std::coroutine_handle;
-}
-#else
-#   include <experimental/coroutine>
-#endif
+
 #include <climits>
 #include <liburing.h>
 #include <type_traits>
 #include <optional>
 #include <cassert>
+
+#include "stdlib_coroutine.hpp"
 
 struct resolver {
     virtual void resolve(int result) noexcept = 0;
@@ -28,7 +21,7 @@ struct resume_resolver final: resolver {
     }
 
 private:
-    std::experimental::coroutine_handle<> handle;
+    std::coroutine_handle<> handle;
     int result = 0;
 };
 static_assert(std::is_trivially_destructible_v<resume_resolver>);
@@ -81,7 +74,7 @@ struct sqe_awaitable {
 
             constexpr bool await_ready() const noexcept { return false; }
 
-            void await_suspend(std::experimental::coroutine_handle<> handle) noexcept {
+            void await_suspend(std::coroutine_handle<> handle) noexcept {
                 resolver.handle = handle;
                 io_uring_sqe_set_data(sqe, &resolver);
             }

--- a/include/stdlib_coroutine.hpp
+++ b/include/stdlib_coroutine.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#if __has_include(<coroutine>)
+
+// This needs to be defined to enable the <coroutine> header in libstdc++ when
+// using clang
+#   if defined(__clang__) && !defined(__cpp_impl_coroutine)
+#      define __cpp_impl_coroutine 201902L
+#   endif
+
+#   include <coroutine>
+
+// std::coroutine_handle and std::coroutine_traits need to be included in
+// std::experimental when using libstdc++ and clang together, however the others
+// don't.
+#   ifdef __clang__
+namespace std::experimental {
+using std::coroutine_handle;
+using std::coroutine_traits;
+} // namespace std::experimental
+#   endif
+
+// If we have the include <experimental/coroutine>, then we need to ensure that
+// std::experimental::* are inside namespace std
+#elif __has_include(<experimental/coroutine>)
+#   include <experimental/coroutine>
+namespace std {
+using std::experimental::coroutine_handle;
+using std::experimental::coroutine_traits;
+using std::experimental::noop_coroutine;
+using std::experimental::noop_coroutine_handle;
+using std::experimental::noop_coroutine_promise;
+using std::experimental::suspend_always;
+using std::experimental::suspend_never;
+} // namespace std
+#endif


### PR DESCRIPTION
This commit adds a file called stdlib_coroutine.hpp, which includes either <coroutine> or <experimental/coroutine> based on which standard library is used. If necessary for that compiler, it also includes std::experimental::<coroutine_stuff> in std, or vice versa.

The code is intended to provide uniform support for:

- Clang with the Clang implementation of the C++ Standard Library (libc++)
- Clang with the GCC implementation of the C++ Standard Library (libstdc++)
- GCC with the GCC implementation of the C++ Standard Library (libstdc++)

This enables instances of `std::experimental` to be replaced with`std` in the code base. So rather than using std::experimental::coroutine_handle, we can use std::coroutine_handle.