### PR TITLE
Created github workflow to build and test liburing4cpp

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,85 @@
+
+name: CMake
+on:
+  push:
+    branches: [ $default-branch, dev/github-workflow]
+  pull_request:
+    branches: [ $default-branch ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ gcc-11, clang-12-libc++ ]
+
+        include:
+          - name: gcc-11
+            compiler: g++-11
+            packages: >
+              g++-11
+            compiler-flags: ""
+
+          - name: clang-12-libc++
+            compiler: clang++-12
+            packages: >
+              clang++-12
+              libc++-12-dev
+              libc++1-12
+              libc++abi1-12
+              libc++abi-12-dev
+            compiler-flags: "-stdlib=libc++"
+
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Package liburing-dev only exists in ubuntu 20.10 and later, so we have to
+    # install it manually
+    - name: Install liburing
+      working-directory: "/tmp"
+      run: |
+        git clone https://github.com/axboe/liburing.git
+        cd liburing
+        ./configure
+        make -j 8
+        sudo make install
+
+    - name: Install Compilers
+      run: |
+        sudo apt-get install ${{ matrix.packages }}
+
+    - name: Configure CMake
+      working-directory: ${{ github.workspace }}
+      run: >
+        cmake
+        -B build
+        -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+        -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+        -DCMAKE_CXX_FLAGS="${{ matrix.compiler-flags }}"
+
+    - name: Build
+      working-directory: ${{ github.workspace }}
+      # Build your program with the given configuration
+      run: >
+        cmake
+        --build build
+        --config ${{ env.BUILD_TYPE }}
+
+
+    # TODO: create test programs in test/ directory, register these with CTest
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}


### PR DESCRIPTION
Hi Carter,

I created a github workflow to build and test the library with gcc and also with clang! We don't have any programs registered as tests right now, but doing that would be pretty straight-forward! (We should probably put them in a directory called `test/` or `tests/`, instead of `demo`, as that would make it much easier to sort them out and register them as tests inside the CMakeLists.txt)

Currently, compilation fails when using clang together with gcc's libstdc++, so I didn't include that combination in the build matrix, however if #11 is merged in, it should fix that issue.

Because this project is open source, Github provides Github Actions for free, so we don't need to spend any money to have it. 