### PR TITLE
Removed fmt module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "fmt"]
-	path = fmt
-	url = https://github.com/fmtlib/fmt.git


### PR DESCRIPTION
Having *fmt* added as a git module isn't necessary for the project. If
no system installation for fmt can be found, CMake will automatically
download one as part of the build process. The master branch also
removed the fmt module, so I thought it appropriate to remove it here
as well.