### PR TITLE
Added Presets for CMake 3.19 & Above

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,64 @@
+{
+    "version": 2,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 19,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "Release",
+            "displayName": "Configure Release",
+            "description": "Release Preset",
+            "binaryDir": "${sourceDir}/build",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "Debug",
+            "displayName": "Configure Debug",
+            "description": "Debug Preset",
+            "binaryDir": "${sourceDir}/build",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "Sanitize",
+            "displayName": "Configure for Address Sanitizer",
+            "description": "Configure for address sanitizer",
+            "binaryDir": "${sourceDir}/build",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "ALWAYS_FETCH": "ON",
+                "CMAKE_CXX_FLAGS": "-stdlib=libc++ -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "Release",
+            "configurePreset": "Release",
+            "configuration": "Release",
+            "jobs": 8
+        },
+        {
+            "name": "Debug",
+            "configurePreset": "Debug",
+            "configuration": "Debug",
+            "jobs": 8
+        },
+        {
+            "name": "Sanitize",
+            "configurePreset": "Sanitize",
+            "configuration": "Debug",
+            "jobs": 8
+        }
+    ]
+}


### PR DESCRIPTION
This commit adds a CMakePresets.json to the project. CMake Presets were first added in CMake version 3.19 (see: https://cmake.org/cmake/help/v3.19/manual/cmake-presets.7.html), and they simplify the building process by allowing certain build configurations to be easily and quickly run from the command line.

This commit adds three presets: Debug, Release, and Sanitize (which is Debug with clang's address sanitizer enabled). To use each, run either:

- `cmake --preset=Debug` for Debug configuration,
- `cmake --preset=Release` for Release, or
- `cmake --preset=Sanitize` in order to build the project using clang's address sanitizer. 

Then, run `cmake --build build` as normal in order to build.

Please note that CMake Presets are a newer addition to CMake, present in CMake versions 3.19 and above. Also, by default the presets use Ninja as the generator, as Ninja typically runs faster than Make, and is less verbose with it's output on a successful build. See: https://ninja-build.org/

Signed-off-by: Alecto Irene Perez <perez.cs@pm.me>