### PR TITLE
Expanded scope of Github Actions builds

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,10 +1,6 @@
 
 name: CMake
-on:
-  push:
-    branches: [ $default-branch, dev/github-workflow]
-  pull_request:
-    branches: [ $default-branch ]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
Previously there was an error in github actions where it was only running on particular branches. This fixes that so that it should run on both push events and on pull requests on all branches.