### PR TITLE
Added .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 5
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+
+PenaltyBreakAssignment: 500
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 10000000
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/demo/bench.cpp
+++ b/demo/bench.cpp
@@ -5,7 +5,8 @@
 #include <liburing/io_service.hpp>
 
 struct stopwatch {
-    stopwatch(std::string_view str_): str(str_) {}
+    stopwatch(std::string_view str_)
+      : str(str_) {}
     ~stopwatch() {
         fmt::print("{:<20}{:>12}\n", str, (clock::now() - start).count());
     }
@@ -22,7 +23,7 @@ int main() {
     io_service service;
     const auto iteration = 10000000;
 
-    service.run([] (io_service& service) -> task<> {
+    service.run([](io_service& service) -> task<> {
         {
             stopwatch sw("service.yield:");
             for (int i = 0; i < iteration; ++i) {
@@ -37,9 +38,9 @@ int main() {
                 io_uring_prep_nop(sqe);
                 io_uring_submit_and_wait(ring, 1);
 
-                io_uring_cqe *cqe;
+                io_uring_cqe* cqe;
                 io_uring_peek_cqe(ring, &cqe);
-                (void) cqe->res;
+                (void)cqe->res;
                 io_uring_cqe_seen(ring, cqe);
             }
         }

--- a/demo/echo_server.cpp
+++ b/demo/echo_server.cpp
@@ -22,56 +22,88 @@ int runningCoroutines = 0;
 uio::task<> accept_connection(uio::io_service& service, int serverfd) {
     while (int clientfd = co_await service.accept(serverfd, nullptr, nullptr)) {
         // [=, &service](int clientfd) -> task<> {
-            fmt::print("sockfd {} is accepted; number of running coroutines: {}\n",
-                clientfd, ++runningCoroutines);
+        fmt::print(
+            "sockfd {} is accepted; number of running coroutines: {}\n",
+            clientfd,
+            ++runningCoroutines);
 #if USE_SPLICE
-            int pipefds[2];
-            pipe(pipefds) | panic_on_err("pipe", true);
-            on_scope_exit([&] { close(pipefds[0]); close(pipefds[1]); });
+        int pipefds[2];
+        pipe(pipefds) | panic_on_err("pipe", true);
+        on_scope_exit([&] {
+            close(pipefds[0]);
+            close(pipefds[1]);
+        });
 #else
-            std::vector<char> buf(BUF_SIZE);
+        std::vector<char> buf(BUF_SIZE);
 #endif
-            while (true) {
+        while (true) {
 #if USE_POLL
-#   if USE_LINK
-                service.poll(clientfd, POLLIN, IOSQE_IO_LINK);
-#   else
-                co_await service.poll(clientfd, POLLIN);
-#   endif
+#    if USE_LINK
+            service.poll(clientfd, POLLIN, IOSQE_IO_LINK);
+#    else
+            co_await service.poll(clientfd, POLLIN);
+#    endif
 #endif
 #if USE_SPLICE
-#   if USE_LINK
-                service.splice(clientfd, -1, pipefds[1], -1, -1, SPLICE_F_MOVE, IOSQE_IO_HARDLINK);
-                int r = co_await service.splice(pipefds[0], -1, clientfd, -1, -1, SPLICE_F_MOVE | SPLICE_F_NONBLOCK);
-                if (r <= 0) break;
-#   else
-                int r = co_await service.splice(clientfd, -1, pipefds[1], -1, -1, SPLICE_F_MOVE);
-                if (r <= 0) break;
-                co_await service.splice(pipefds[0], -1, clientfd, -1, r, SPLICE_F_MOVE);
-#   endif
+#    if USE_LINK
+            service.splice(
+                clientfd,
+                -1,
+                pipefds[1],
+                -1,
+                -1,
+                SPLICE_F_MOVE,
+                IOSQE_IO_HARDLINK);
+            int r = co_await service.splice(
+                pipefds[0],
+                -1,
+                clientfd,
+                -1,
+                -1,
+                SPLICE_F_MOVE | SPLICE_F_NONBLOCK);
+            if (r <= 0)
+                break;
+#    else
+            int r = co_await service.splice(
+                clientfd,
+                -1,
+                pipefds[1],
+                -1,
+                -1,
+                SPLICE_F_MOVE);
+            if (r <= 0)
+                break;
+            co_await service
+                .splice(pipefds[0], -1, clientfd, -1, r, SPLICE_F_MOVE);
+#    endif
 #else
-#   if USE_LINK
-#       error "This won't work because short read of IORING_OP_RECV is not considered an error"
-#   else
-                int r = co_await service.recv(clientfd, buf.data(), BUF_SIZE, MSG_NOSIGNAL);
-                if (r <= 0) break;
-                co_await service.send(clientfd, buf.data(), r, MSG_NOSIGNAL);
-#   endif
+#    if USE_LINK
+#        error                                                                 \
+            "This won't work because short read of IORING_OP_RECV is not considered an error"
+#    else
+            int r = co_await service
+                        .recv(clientfd, buf.data(), BUF_SIZE, MSG_NOSIGNAL);
+            if (r <= 0)
+                break;
+            co_await service.send(clientfd, buf.data(), r, MSG_NOSIGNAL);
+#    endif
 #endif
-            }
-            service.shutdown(clientfd, SHUT_RDWR, IOSQE_IO_LINK);
-            co_await service.close(clientfd);
-            fmt::print("sockfd {} is closed; number of running coroutines: {}\n",
-                clientfd, --runningCoroutines);
+        }
+        service.shutdown(clientfd, SHUT_RDWR, IOSQE_IO_LINK);
+        co_await service.close(clientfd);
+        fmt::print(
+            "sockfd {} is closed; number of running coroutines: {}\n",
+            clientfd,
+            --runningCoroutines);
         // }(clientfd);
     }
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     using uio::io_service;
-    using uio::panic_on_err;
     using uio::on_scope_exit;
     using uio::panic;
+    using uio::panic_on_err;
 
     uint16_t server_port = 0;
     if (argc == 2) {
@@ -84,17 +116,22 @@ int main(int argc, char *argv[]) {
 
     io_service service(MAX_CONN_SIZE);
 
-    int sockfd = socket(AF_INET, SOCK_STREAM, 0) | panic_on_err("socket creation", true);
+    int sockfd = socket(AF_INET, SOCK_STREAM, 0)
+               | panic_on_err("socket creation", true);
     on_scope_exit closesock([=]() { shutdown(sockfd, SHUT_RDWR); });
 
-    if (sockaddr_in addr = {
-        .sin_family = AF_INET,
-        .sin_port = htons(server_port),
-        .sin_addr = { INADDR_ANY },
-        .sin_zero = {},
-    }; bind(sockfd, reinterpret_cast<sockaddr *>(&addr), sizeof (sockaddr_in))) panic("socket binding", errno);
+    if (sockaddr_in addr =
+            {
+                .sin_family = AF_INET,
+                .sin_port = htons(server_port),
+                .sin_addr = {INADDR_ANY},
+                .sin_zero = {},
+            };
+        bind(sockfd, reinterpret_cast<sockaddr*>(&addr), sizeof(sockaddr_in)))
+        panic("socket binding", errno);
 
-    if (listen(sockfd, MAX_CONN_SIZE * 2)) panic("listen", errno);
+    if (listen(sockfd, MAX_CONN_SIZE * 2))
+        panic("listen", errno);
     fmt::print("Listening: {}\n", server_port);
 
     service.run(accept_connection(service, sockfd));

--- a/demo/file_server.cpp
+++ b/demo/file_server.cpp
@@ -21,24 +21,38 @@ enum {
 using namespace std::literals;
 
 // Predefined HTTP error response headers
-static constexpr const auto http_400_hdr = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n"sv;
-static constexpr const auto http_403_hdr = "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n"sv;
-static constexpr const auto http_404_hdr = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"sv;
+static constexpr const auto
+    http_400_hdr = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n"sv;
+static constexpr const auto
+    http_403_hdr = "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n"sv;
+static constexpr const auto
+    http_404_hdr = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"sv;
 
 int runningCoroutines = 0;
 
 // Serve response
-uio::task<> http_send_file(uio::io_service& service, std::string filename, int clientfd, int dirfd) {
+uio::task<> http_send_file(
+    uio::io_service& service,
+    std::string filename,
+    int clientfd,
+    int dirfd) {
+    using uio::dur2ts;
     using uio::on_scope_exit;
     using uio::panic_on_err;
-    using uio::dur2ts;
 
-    if (filename == "./") filename = "./index.html";
+    if (filename == "./")
+        filename = "./index.html";
 
-    const auto infd = co_await service.openat(dirfd, filename.c_str(), O_RDONLY, 0);
+    const auto infd = co_await service
+                          .openat(dirfd, filename.c_str(), O_RDONLY, 0);
     if (infd < 0) {
         fmt::print("{}: file not found!\n", filename);
-        co_await service.send(clientfd, http_404_hdr.data(), http_404_hdr.size(), MSG_NOSIGNAL) | uio::panic_on_err("send" , false);
+        co_await service.send(
+            clientfd,
+            http_404_hdr.data(),
+            http_404_hdr.size(),
+            MSG_NOSIGNAL)
+            | uio::panic_on_err("send", false);
         co_return;
     }
 
@@ -46,30 +60,69 @@ uio::task<> http_send_file(uio::io_service& service, std::string filename, int c
 
     if (struct stat st; fstat(infd, &st) || !S_ISREG(st.st_mode)) {
         fmt::print("{}: not a regular file!\n", filename);
-        co_await service.send(clientfd, http_403_hdr.data(), http_403_hdr.size(), MSG_NOSIGNAL) | panic_on_err("send" , false);
+        co_await service.send(
+            clientfd,
+            http_403_hdr.data(),
+            http_403_hdr.size(),
+            MSG_NOSIGNAL)
+            | panic_on_err("send", false);
     } else {
         auto contentType = [filename_view = std::string_view(filename)]() {
-            auto extension = filename_view.substr(filename_view.find_last_of('.') + 1);
-            if (extension == "txt"sv || extension == "c"sv || extension == "cpp"sv || extension == "h"sv || extension == "hpp"sv) {
+            auto extension = filename_view.substr(
+                filename_view.find_last_of('.') + 1);
+            if (extension == "txt"sv || extension == "c"sv
+                || extension == "cpp"sv || extension == "h"sv
+                || extension == "hpp"sv) {
                 return "text/plain"sv;
             }
             return "application/octet-stream"sv;
         }();
 
-        auto header = fmt::format("HTTP/1.1 200 OK\r\nContent-type: {}\r\nContent-Length: {}\r\n\r\n", contentType, st.st_size);
-        co_await service.send(clientfd, header.data(), header.size(), MSG_NOSIGNAL | MSG_MORE) | panic_on_err("send" , false);
+        auto header = fmt::format(
+            "HTTP/1.1 200 OK\r\nContent-type: {}\r\nContent-Length: {}\r\n\r\n",
+            contentType,
+            st.st_size);
+        co_await service.send(
+            clientfd,
+            header.data(),
+            header.size(),
+            MSG_NOSIGNAL | MSG_MORE)
+            | panic_on_err("send", false);
 
         off_t offset = 0;
         std::array<char, BUF_SIZE> filebuf;
         for (; st.st_size - offset > BUF_SIZE; offset += BUF_SIZE) {
-            auto t = service.read(infd, filebuf.data(), filebuf.size(), offset, IOSQE_IO_LINK) | panic_on_err("read" , false);
-            co_await service.send(clientfd, filebuf.data(), filebuf.size(), MSG_NOSIGNAL | MSG_MORE) | panic_on_err("send", false);
+            auto t = service.read(
+                         infd,
+                         filebuf.data(),
+                         filebuf.size(),
+                         offset,
+                         IOSQE_IO_LINK)
+                   | panic_on_err("read", false);
+            co_await service.send(
+                clientfd,
+                filebuf.data(),
+                filebuf.size(),
+                MSG_NOSIGNAL | MSG_MORE)
+                | panic_on_err("send", false);
             auto ts = dur2ts(100ms);
-            co_await service.timeout(&ts) | panic_on_err("timeout" , false); // For debugging
+            co_await service.timeout(&ts)
+                | panic_on_err("timeout", false); // For debugging
         }
         if (st.st_size > offset) {
-            auto t = service.read(infd, filebuf.data(), st.st_size - offset, offset, IOSQE_IO_LINK) | panic_on_err("read", false);
-            co_await service.send(clientfd, filebuf.data(), st.st_size - offset, MSG_NOSIGNAL) | panic_on_err("send", false);
+            auto t = service.read(
+                         infd,
+                         filebuf.data(),
+                         st.st_size - offset,
+                         offset,
+                         IOSQE_IO_LINK)
+                   | panic_on_err("read", false);
+            co_await service.send(
+                clientfd,
+                filebuf.data(),
+                st.st_size - offset,
+                MSG_NOSIGNAL)
+                | panic_on_err("send", false);
         }
     }
 }
@@ -78,12 +131,15 @@ uio::task<> http_send_file(uio::io_service& service, std::string filename, int c
 uio::task<> serve(uio::io_service& service, int clientfd, int dirfd) {
     using uio::panic_on_err;
 
-    fmt::print("Serving connection, sockfd {}; number of running coroutines: {}\n",
-         clientfd, runningCoroutines);
+    fmt::print(
+        "Serving connection, sockfd {}; number of running coroutines: {}\n",
+        clientfd,
+        runningCoroutines);
 
     std::array<char, BUF_SIZE> buffer;
 
-    int res = co_await service.recv(clientfd, buffer.data(), buffer.size(), 0) | panic_on_err("recv", false);
+    int res = co_await service.recv(clientfd, buffer.data(), buffer.size(), 0)
+            | panic_on_err("recv", false);
 
     std::string_view buf_view = std::string_view(buffer.data(), size_t(res));
 
@@ -94,11 +150,19 @@ uio::task<> serve(uio::io_service& service, int clientfd, int dirfd) {
         co_await http_send_file(service, file, clientfd, dirfd);
     } else {
         fmt::print("unsupported request: {}\n", buf_view);
-        co_await service.send(clientfd, http_400_hdr.data(), http_400_hdr.size(), MSG_NOSIGNAL) | panic_on_err("send", false);
+        co_await service.send(
+            clientfd,
+            http_400_hdr.data(),
+            http_400_hdr.size(),
+            MSG_NOSIGNAL)
+            | panic_on_err("send", false);
     }
 }
 
-uio::task<> accept_connection(uio::io_service& service, int serverfd, int dirfd) {
+uio::task<> accept_connection(
+    uio::io_service& service,
+    int serverfd,
+    int dirfd) {
     using uio::task;
 
     while (int clientfd = co_await service.accept(serverfd, nullptr, nullptr)) {
@@ -109,7 +173,8 @@ uio::task<> accept_connection(uio::io_service& service, int serverfd, int dirfd)
             try {
                 co_await serve(service, clientfd, dirfd);
             } catch (std::exception& e) {
-                fmt::print("sockfd {} crashed with exception: {}\n",
+                fmt::print(
+                    "sockfd {} crashed with exception: {}\n",
                     clientfd,
                     e.what());
             }
@@ -117,7 +182,8 @@ uio::task<> accept_connection(uio::io_service& service, int serverfd, int dirfd)
             // Clean up
             co_await service.shutdown(clientfd, SHUT_RDWR);
             co_await service.close(clientfd);
-            fmt::print("sockfd {} is closed, time used {:%T}\n",
+            fmt::print(
+                "sockfd {} is closed, time used {:%T}\n",
                 clientfd,
                 std::chrono::high_resolution_clock::now() - start);
             --runningCoroutines;
@@ -126,10 +192,10 @@ uio::task<> accept_connection(uio::io_service& service, int serverfd, int dirfd)
 }
 
 int main(int argc, char* argv[]) {
-    using uio::panic_on_err;
+    using uio::io_service;
     using uio::on_scope_exit;
     using uio::panic;
-    using uio::io_service;
+    using uio::panic_on_err;
 
     if (argc != 2) {
         fmt::print("Usage: {} <ROOT_DIR>\n", argv[0]);
@@ -139,20 +205,29 @@ int main(int argc, char* argv[]) {
     int dirfd = open(argv[1], O_DIRECTORY) | panic_on_err("open dir", true);
     on_scope_exit closedir([=]() { close(dirfd); });
 
-    int sockfd = socket(AF_INET, SOCK_STREAM, 0) | panic_on_err("socket creation", true);
+    int sockfd = socket(AF_INET, SOCK_STREAM, 0)
+               | panic_on_err("socket creation", true);
     on_scope_exit closesock([=]() { close(sockfd); });
 
-    if (int on = 1; setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof (on))) panic("SO_REUSEADDR", errno);
-    if (int on = 1; setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof (on))) panic("SO_REUSEPORT", errno);
+    if (int on = 1;
+        setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)))
+        panic("SO_REUSEADDR", errno);
+    if (int on = 1;
+        setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)))
+        panic("SO_REUSEPORT", errno);
 
-    if (sockaddr_in addr = {
-        .sin_family = AF_INET,
-        .sin_port = htons(SERVER_PORT),
-        .sin_addr = { INADDR_ANY },
-        .sin_zero = {}, // Silense compiler warnings
-    }; bind(sockfd, reinterpret_cast<sockaddr *>(&addr), sizeof (sockaddr_in))) panic("socket binding", errno);
+    if (sockaddr_in addr =
+            {
+                .sin_family = AF_INET,
+                .sin_port = htons(SERVER_PORT),
+                .sin_addr = {INADDR_ANY},
+                .sin_zero = {}, // Silense compiler warnings
+            };
+        bind(sockfd, reinterpret_cast<sockaddr*>(&addr), sizeof(sockaddr_in)))
+        panic("socket binding", errno);
 
-    if (listen(sockfd, 128)) panic("listen", errno);
+    if (listen(sockfd, 128))
+        panic("listen", errno);
     fmt::print("Listening: {}\n", SERVER_PORT);
 
     io_service service;

--- a/demo/http_client.cpp
+++ b/demo/http_client.cpp
@@ -14,31 +14,55 @@
 #include <liburing/io_service.hpp>
 
 uio::task<> start_work(uio::io_service& service, const char* hostname) {
-    addrinfo hints = {
-        .ai_family = AF_UNSPEC,
-        .ai_socktype = SOCK_STREAM,
-    }, *addrs;
+    addrinfo hints =
+                 {
+                     .ai_family = AF_UNSPEC,
+                     .ai_socktype = SOCK_STREAM,
+                 },
+             *addrs;
     if (int ret = getaddrinfo(hostname, "http", &hints, &addrs); ret < 0) {
-        fmt::print(stderr, "getaddrinfo({}): {}\n", hostname, gai_strerror(ret));
+        fmt::print(
+            stderr,
+            "getaddrinfo({}): {}\n",
+            hostname,
+            gai_strerror(ret));
         throw std::runtime_error("getaddrinfo");
     }
     uio::on_scope_exit freeaddr([=]() { freeaddrinfo(addrs); });
 
-    for (struct addrinfo *addr = addrs; addr; addr = addr->ai_next) {
-        int clientfd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol) | uio::panic_on_err("socket creation", true);
+    for (struct addrinfo* addr = addrs; addr; addr = addr->ai_next) {
+        int clientfd = socket(
+                           addr->ai_family,
+                           addr->ai_socktype,
+                           addr->ai_protocol)
+                     | uio::panic_on_err("socket creation", true);
         uio::on_scope_exit closesock([&]() { service.close(clientfd); });
 
-        if (co_await service.connect(clientfd, addr->ai_addr, addr->ai_addrlen) < 0) continue;
+        if (co_await service.connect(clientfd, addr->ai_addr, addr->ai_addrlen)
+            < 0)
+            continue;
 
-        auto header = fmt::format("GET / HTTP/1.0\r\nHost: {}\r\nAccept: */*\r\n\r\n", hostname);
-        co_await service.send(clientfd, header.data(), header.size(), MSG_NOSIGNAL) | uio::panic_on_err("send", false);
+        auto header = fmt::format(
+            "GET / HTTP/1.0\r\nHost: {}\r\nAccept: */*\r\n\r\n",
+            hostname);
+        co_await service
+                .send(clientfd, header.data(), header.size(), MSG_NOSIGNAL)
+            | uio::panic_on_err("send", false);
 
         std::array<char, 1024> buffer;
         int res;
         for (;;) {
-            res = co_await service.recv(clientfd, buffer.data(), buffer.size(), MSG_NOSIGNAL | MSG_MORE) | uio::panic_on_err("recv", false);
-            if (res == 0) break;
-            co_await service.write(STDOUT_FILENO, buffer.data(), unsigned(res), 0) | uio::panic_on_err("write", false);
+            res = co_await service.recv(
+                      clientfd,
+                      buffer.data(),
+                      buffer.size(),
+                      MSG_NOSIGNAL | MSG_MORE)
+                | uio::panic_on_err("recv", false);
+            if (res == 0)
+                break;
+            co_await service
+                    .write(STDOUT_FILENO, buffer.data(), unsigned(res), 0)
+                | uio::panic_on_err("write", false);
         }
 
         co_return;

--- a/include/liburing/io_service.hpp
+++ b/include/liburing/io_service.hpp
@@ -7,9 +7,9 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <liburing.h>   // http://git.kernel.dk/liburing
+#include <liburing.h> // http://git.kernel.dk/liburing
 #ifndef NDEBUG
-#   include <execinfo.h>
+#    include <execinfo.h>
 #endif
 
 #include <liburing/sqe_awaitable.hpp>
@@ -17,16 +17,16 @@
 #include <liburing/utils.hpp>
 
 #ifdef LIBURING_VERBOSE
-#   define puts_if_verbose(x) puts(x)
-#   define printf_if_verbose(...) printf(__VA_ARGS__)
+#    define puts_if_verbose(x) puts(x)
+#    define printf_if_verbose(...) printf(__VA_ARGS__)
 #else
-#   define puts_if_verbose(x) 0
-#   define printf_if_verbose(...) 0
+#    define puts_if_verbose(x) 0
+#    define printf_if_verbose(...) 0
 #endif
 
 namespace uio {
 class io_service {
-public:
+   public:
     /** Init io_service / io_uring object
      * @see io_uring_setup(2)
      * @param entries Maximum sqe can be gotten without submitting
@@ -34,9 +34,9 @@ public:
      * @param wq_fd existing io_uring ring_fd used by IORING_SETUP_ATTACH_WQ
      * @note io_service is NOT thread safe, nor is liburing. When used in a
      *       multi-threaded program, it's highly recommended to create
-     *       io_service/io_uring instance per thread, and set IORING_SETUP_ATTACH_WQ
-     *       flag to make sure that kernel shares the only async worker thread pool.
-     *       See `IORING_SETUP_ATTACH_WQ` for detail.
+     *       io_service/io_uring instance per thread, and set
+     * IORING_SETUP_ATTACH_WQ flag to make sure that kernel shares the only
+     * async worker thread pool. See `IORING_SETUP_ATTACH_WQ` for detail.
      */
     io_service(int entries = 64, uint32_t flags = 0, uint32_t wq_fd = 0) {
         io_uring_params p = {
@@ -44,89 +44,91 @@ public:
             .wq_fd = wq_fd,
         };
 
-        io_uring_queue_init_params(entries, &ring, &p) | panic_on_err("queue_init_params", false);
+        io_uring_queue_init_params(entries, &ring, &p)
+            | panic_on_err("queue_init_params", false);
 
         auto* probe = io_uring_get_probe_ring(&ring);
         on_scope_exit free_probe([=]() { io_uring_free_probe(probe); });
-#define TEST_IORING_OP(opcode) do {\
-    for (int i = 0; i < probe->ops_len; ++i) {\
-        if (probe->ops[i].op == opcode && probe->ops[i].flags & IO_URING_OP_SUPPORTED) {\
-                probe_ops[i] = true;\
-                puts_if_verbose("\t" #opcode);\
-                break;\
-            }\
-        }\
+#define TEST_IORING_OP(opcode)                                                 \
+    do {                                                                       \
+        for (int i = 0; i < probe->ops_len; ++i) {                             \
+            if (probe->ops[i].op == opcode                                     \
+                && probe->ops[i].flags & IO_URING_OP_SUPPORTED) {              \
+                probe_ops[i] = true;                                           \
+                puts_if_verbose("\t" #opcode);                                 \
+                break;                                                         \
+            }                                                                  \
+        }                                                                      \
     } while (0)
-    puts_if_verbose("Supported io_uring opcodes by current kernel:");
-    TEST_IORING_OP(IORING_OP_NOP);
-    TEST_IORING_OP(IORING_OP_READV);
-    TEST_IORING_OP(IORING_OP_WRITEV);
-    TEST_IORING_OP(IORING_OP_FSYNC);
-    TEST_IORING_OP(IORING_OP_READ_FIXED);
-    TEST_IORING_OP(IORING_OP_WRITE_FIXED);
-    TEST_IORING_OP(IORING_OP_POLL_ADD);
-    TEST_IORING_OP(IORING_OP_POLL_REMOVE);
-    TEST_IORING_OP(IORING_OP_SYNC_FILE_RANGE);
-    TEST_IORING_OP(IORING_OP_SENDMSG);
-    TEST_IORING_OP(IORING_OP_RECVMSG);
-    TEST_IORING_OP(IORING_OP_TIMEOUT);
-    TEST_IORING_OP(IORING_OP_TIMEOUT_REMOVE);
-    TEST_IORING_OP(IORING_OP_ACCEPT);
-    TEST_IORING_OP(IORING_OP_ASYNC_CANCEL);
-    TEST_IORING_OP(IORING_OP_LINK_TIMEOUT);
-    TEST_IORING_OP(IORING_OP_CONNECT);
-    TEST_IORING_OP(IORING_OP_FALLOCATE);
-    TEST_IORING_OP(IORING_OP_OPENAT);
-    TEST_IORING_OP(IORING_OP_CLOSE);
-    TEST_IORING_OP(IORING_OP_FILES_UPDATE);
-    TEST_IORING_OP(IORING_OP_STATX);
-    TEST_IORING_OP(IORING_OP_READ);
-    TEST_IORING_OP(IORING_OP_WRITE);
-    TEST_IORING_OP(IORING_OP_FADVISE);
-    TEST_IORING_OP(IORING_OP_MADVISE);
-    TEST_IORING_OP(IORING_OP_SEND);
-    TEST_IORING_OP(IORING_OP_RECV);
-    TEST_IORING_OP(IORING_OP_OPENAT2);
-    TEST_IORING_OP(IORING_OP_EPOLL_CTL);
-    TEST_IORING_OP(IORING_OP_SPLICE);
-    TEST_IORING_OP(IORING_OP_PROVIDE_BUFFERS);
-    TEST_IORING_OP(IORING_OP_REMOVE_BUFFERS);
-    TEST_IORING_OP(IORING_OP_TEE);
-    TEST_IORING_OP(IORING_OP_SHUTDOWN);
-    TEST_IORING_OP(IORING_OP_RENAMEAT);
-    TEST_IORING_OP(IORING_OP_UNLINKAT);
-    TEST_IORING_OP(IORING_OP_MKDIRAT);
-    TEST_IORING_OP(IORING_OP_SYMLINKAT);
-    TEST_IORING_OP(IORING_OP_LINKAT);
+        puts_if_verbose("Supported io_uring opcodes by current kernel:");
+        TEST_IORING_OP(IORING_OP_NOP);
+        TEST_IORING_OP(IORING_OP_READV);
+        TEST_IORING_OP(IORING_OP_WRITEV);
+        TEST_IORING_OP(IORING_OP_FSYNC);
+        TEST_IORING_OP(IORING_OP_READ_FIXED);
+        TEST_IORING_OP(IORING_OP_WRITE_FIXED);
+        TEST_IORING_OP(IORING_OP_POLL_ADD);
+        TEST_IORING_OP(IORING_OP_POLL_REMOVE);
+        TEST_IORING_OP(IORING_OP_SYNC_FILE_RANGE);
+        TEST_IORING_OP(IORING_OP_SENDMSG);
+        TEST_IORING_OP(IORING_OP_RECVMSG);
+        TEST_IORING_OP(IORING_OP_TIMEOUT);
+        TEST_IORING_OP(IORING_OP_TIMEOUT_REMOVE);
+        TEST_IORING_OP(IORING_OP_ACCEPT);
+        TEST_IORING_OP(IORING_OP_ASYNC_CANCEL);
+        TEST_IORING_OP(IORING_OP_LINK_TIMEOUT);
+        TEST_IORING_OP(IORING_OP_CONNECT);
+        TEST_IORING_OP(IORING_OP_FALLOCATE);
+        TEST_IORING_OP(IORING_OP_OPENAT);
+        TEST_IORING_OP(IORING_OP_CLOSE);
+        TEST_IORING_OP(IORING_OP_FILES_UPDATE);
+        TEST_IORING_OP(IORING_OP_STATX);
+        TEST_IORING_OP(IORING_OP_READ);
+        TEST_IORING_OP(IORING_OP_WRITE);
+        TEST_IORING_OP(IORING_OP_FADVISE);
+        TEST_IORING_OP(IORING_OP_MADVISE);
+        TEST_IORING_OP(IORING_OP_SEND);
+        TEST_IORING_OP(IORING_OP_RECV);
+        TEST_IORING_OP(IORING_OP_OPENAT2);
+        TEST_IORING_OP(IORING_OP_EPOLL_CTL);
+        TEST_IORING_OP(IORING_OP_SPLICE);
+        TEST_IORING_OP(IORING_OP_PROVIDE_BUFFERS);
+        TEST_IORING_OP(IORING_OP_REMOVE_BUFFERS);
+        TEST_IORING_OP(IORING_OP_TEE);
+        TEST_IORING_OP(IORING_OP_SHUTDOWN);
+        TEST_IORING_OP(IORING_OP_RENAMEAT);
+        TEST_IORING_OP(IORING_OP_UNLINKAT);
+        TEST_IORING_OP(IORING_OP_MKDIRAT);
+        TEST_IORING_OP(IORING_OP_SYMLINKAT);
+        TEST_IORING_OP(IORING_OP_LINKAT);
 #undef TEST_IORING_OP
 
-#define TEST_IORING_FEATURE(feature) if (p.features & feature) puts_if_verbose("\t" #feature)
-    puts_if_verbose("Supported io_uring features by current kernel:");
-    TEST_IORING_FEATURE(IORING_FEAT_SINGLE_MMAP);
-    TEST_IORING_FEATURE(IORING_FEAT_NODROP);
-    TEST_IORING_FEATURE(IORING_FEAT_SUBMIT_STABLE);
-    TEST_IORING_FEATURE(IORING_FEAT_RW_CUR_POS);
-    TEST_IORING_FEATURE(IORING_FEAT_CUR_PERSONALITY);
-    TEST_IORING_FEATURE(IORING_FEAT_FAST_POLL);
-    TEST_IORING_FEATURE(IORING_FEAT_POLL_32BITS);
-    TEST_IORING_FEATURE(IORING_FEAT_SQPOLL_NONFIXED);
-    TEST_IORING_FEATURE(IORING_FEAT_EXT_ARG);
-    TEST_IORING_FEATURE(IORING_FEAT_NATIVE_WORKERS);
-    TEST_IORING_FEATURE(IORING_FEAT_RSRC_TAGS);
+#define TEST_IORING_FEATURE(feature)                                           \
+    if (p.features & feature)                                                  \
+    puts_if_verbose("\t" #feature)
+        puts_if_verbose("Supported io_uring features by current kernel:");
+        TEST_IORING_FEATURE(IORING_FEAT_SINGLE_MMAP);
+        TEST_IORING_FEATURE(IORING_FEAT_NODROP);
+        TEST_IORING_FEATURE(IORING_FEAT_SUBMIT_STABLE);
+        TEST_IORING_FEATURE(IORING_FEAT_RW_CUR_POS);
+        TEST_IORING_FEATURE(IORING_FEAT_CUR_PERSONALITY);
+        TEST_IORING_FEATURE(IORING_FEAT_FAST_POLL);
+        TEST_IORING_FEATURE(IORING_FEAT_POLL_32BITS);
+        TEST_IORING_FEATURE(IORING_FEAT_SQPOLL_NONFIXED);
+        TEST_IORING_FEATURE(IORING_FEAT_EXT_ARG);
+        TEST_IORING_FEATURE(IORING_FEAT_NATIVE_WORKERS);
+        TEST_IORING_FEATURE(IORING_FEAT_RSRC_TAGS);
 #undef TEST_IORING_FEATURE
     }
 
     /** Destroy io_service / io_uring object */
-    ~io_service() noexcept {
-        io_uring_queue_exit(&ring);
-    }
+    ~io_service() noexcept { io_uring_queue_exit(&ring); }
 
     // io_service is not copyable. It can be moveable but humm...
     io_service(const io_service&) = delete;
-    io_service& operator =(const io_service&) = delete;
+    io_service& operator=(const io_service&) = delete;
 
-public:
-
+   public:
     /** Read data into multiple buffers asynchronously
      * @see preadv2(2)
      * @see io_uring_enter(2) IORING_OP_READV
@@ -138,8 +140,7 @@ public:
         const iovec* iovecs,
         unsigned nr_vecs,
         off_t offset,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_readv(sqe, fd, iovecs, nr_vecs, offset);
         return await_work(sqe, iflags);
@@ -156,8 +157,7 @@ public:
         const iovec* iovecs,
         unsigned nr_vecs,
         off_t offset,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_writev(sqe, fd, iovecs, nr_vecs, offset);
         return await_work(sqe, iflags);
@@ -174,8 +174,7 @@ public:
         void* buf,
         unsigned nbytes,
         off_t offset,
-        uint8_t iflags = 0
-    ) {
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_read(sqe, fd, buf, nbytes, offset);
         return await_work(sqe, iflags);
@@ -192,8 +191,7 @@ public:
         const void* buf,
         unsigned nbytes,
         off_t offset,
-        uint8_t iflags = 0
-    ) {
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_write(sqe, fd, buf, nbytes, offset);
         return await_work(sqe, iflags);
@@ -212,8 +210,7 @@ public:
         unsigned nbytes,
         off_t offset,
         int buf_index,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_read_fixed(sqe, fd, buf, nbytes, offset, buf_index);
         return await_work(sqe, iflags);
@@ -232,8 +229,7 @@ public:
         unsigned nbytes,
         off_t offset,
         int buf_index,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_write_fixed(sqe, fd, buf, nbytes, offset, buf_index);
         return await_work(sqe, iflags);
@@ -248,8 +244,7 @@ public:
     sqe_awaitable fsync(
         int fd,
         unsigned fsync_flags,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_fsync(sqe, fd, fsync_flags);
         return await_work(sqe, iflags);
@@ -266,10 +261,15 @@ public:
         off64_t offset,
         off64_t nbytes,
         unsigned sync_range_flags,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
-        io_uring_prep_rw(IORING_OP_SYNC_FILE_RANGE, sqe, fd, nullptr, nbytes, offset);
+        io_uring_prep_rw(
+            IORING_OP_SYNC_FILE_RANGE,
+            sqe,
+            fd,
+            nullptr,
+            nbytes,
+            offset);
         sqe->sync_range_flags = sync_range_flags;
         return await_work(sqe, iflags);
     }
@@ -285,8 +285,7 @@ public:
         int sockfd,
         msghdr* msg,
         uint32_t flags,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_recvmsg(sqe, sockfd, msg, flags);
         return await_work(sqe, iflags);
@@ -302,8 +301,7 @@ public:
         int sockfd,
         const msghdr* msg,
         uint32_t flags,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_sendmsg(sqe, sockfd, msg, flags);
         return await_work(sqe, iflags);
@@ -320,8 +318,7 @@ public:
         void* buf,
         unsigned nbytes,
         uint32_t flags,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_recv(sqe, sockfd, buf, nbytes, flags);
         return await_work(sqe, iflags);
@@ -338,8 +335,7 @@ public:
         const void* buf,
         unsigned nbytes,
         uint32_t flags,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_send(sqe, sockfd, buf, nbytes, flags);
         return await_work(sqe, iflags);
@@ -351,24 +347,19 @@ public:
      * @param iflags IOSQE_* flags
      * @return a task object for awaiting
      */
-    sqe_awaitable poll(
-        int fd,
-        short poll_mask,
-        uint8_t iflags = 0
-    ) noexcept {
+    sqe_awaitable poll(int fd, short poll_mask, uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_poll_add(sqe, fd, poll_mask);
         return await_work(sqe, iflags);
     }
 
-    /** Enqueue a NOOP command, which eventually acts like pthread_yield when awaiting
+    /** Enqueue a NOOP command, which eventually acts like pthread_yield when
+     * awaiting
      * @see io_uring_enter(2) IORING_OP_NOP
      * @param iflags IOSQE_* flags
      * @return a task object for awaiting
      */
-    sqe_awaitable yield(
-        uint8_t iflags = 0
-    ) noexcept {
+    sqe_awaitable yield(uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_nop(sqe);
         return await_work(sqe, iflags);
@@ -382,11 +373,10 @@ public:
      */
     sqe_awaitable accept(
         int fd,
-        sockaddr *addr,
-        socklen_t *addrlen,
+        sockaddr* addr,
+        socklen_t* addrlen,
         int flags = 0,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_accept(sqe, fd, addr, addrlen, flags);
         return await_work(sqe, iflags);
@@ -400,11 +390,10 @@ public:
      */
     sqe_awaitable connect(
         int fd,
-        sockaddr *addr,
+        sockaddr* addr,
         socklen_t addrlen,
         int flags = 0,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_connect(sqe, fd, addr, addrlen);
         return await_work(sqe, iflags);
@@ -416,10 +405,7 @@ public:
      * @param iflags IOSQE_* flags
      * @return a task object for awaiting
      */
-    sqe_awaitable timeout(
-        __kernel_timespec *ts,
-        uint8_t iflags = 0
-    ) noexcept {
+    sqe_awaitable timeout(__kernel_timespec* ts, uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_timeout(sqe, ts, 0, 0);
         return await_work(sqe, iflags);
@@ -433,11 +419,10 @@ public:
      */
     sqe_awaitable openat(
         int dfd,
-        const char *path,
+        const char* path,
         int flags,
         mode_t mode,
-        uint8_t iflags = 0
-    ) noexcept {
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_openat(sqe, dfd, path, flags, mode);
         return await_work(sqe, iflags);
@@ -449,10 +434,7 @@ public:
      * @param iflags IOSQE_* flags
      * @return a task object for awaiting
      */
-    sqe_awaitable close(
-        int fd,
-        uint8_t iflags = 0
-    ) noexcept {
+    sqe_awaitable close(int fd, uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_close(sqe, fd);
         return await_work(sqe, iflags);
@@ -466,12 +448,11 @@ public:
      */
     sqe_awaitable statx(
         int dfd,
-        const char *path,
+        const char* path,
         int flags,
         unsigned mask,
-        struct statx *statxbuf,
-        uint8_t iflags = 0
-    ) noexcept {
+        struct statx* statxbuf,
+        uint8_t iflags = 0) noexcept {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_statx(sqe, dfd, path, flags, mask, statxbuf);
         return await_work(sqe, iflags);
@@ -490,10 +471,16 @@ public:
         loff_t off_out,
         size_t nbytes,
         unsigned flags,
-        uint8_t iflags = 0
-    ) {
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
-        io_uring_prep_splice(sqe, fd_in, off_in, fd_out, off_out, nbytes, flags);
+        io_uring_prep_splice(
+            sqe,
+            fd_in,
+            off_in,
+            fd_out,
+            off_out,
+            nbytes,
+            flags);
         return await_work(sqe, iflags);
     }
 
@@ -508,8 +495,7 @@ public:
         int fd_out,
         size_t nbytes,
         unsigned flags,
-        uint8_t iflags = 0
-    ) {
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_tee(sqe, fd_in, fd_out, nbytes, flags);
         return await_work(sqe, iflags);
@@ -521,11 +507,7 @@ public:
      * @param iflags IOSQE_* flags
      * @return a task object for awaiting
      */
-    sqe_awaitable shutdown(
-        int fd,
-        int how,
-        uint8_t iflags = 0
-    ) {
+    sqe_awaitable shutdown(int fd, int how, uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_shutdown(sqe, fd, how);
         return await_work(sqe, iflags);
@@ -539,12 +521,11 @@ public:
      */
     sqe_awaitable renameat(
         int olddfd,
-        const char *oldpath,
+        const char* oldpath,
         int newdfd,
-        const char *newpath,
+        const char* newpath,
         unsigned flags,
-        uint8_t iflags = 0
-    ) {
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_renameat(sqe, olddfd, oldpath, newdfd, newpath, flags);
         return await_work(sqe, iflags);
@@ -558,10 +539,9 @@ public:
      */
     sqe_awaitable mkdirat(
         int dirfd,
-        const char *pathname,
+        const char* pathname,
         mode_t mode,
-        uint8_t iflags = 0
-    ) {
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_mkdirat(sqe, dirfd, pathname, mode);
         return await_work(sqe, iflags);
@@ -574,11 +554,10 @@ public:
      * @return a task object for awaiting
      */
     sqe_awaitable symlinkat(
-        const char *target,
+        const char* target,
         int newdirfd,
-        const char *linkpath,
-        uint8_t iflags = 0
-    ) {
+        const char* linkpath,
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_symlinkat(sqe, target, newdirfd, linkpath);
         return await_work(sqe, iflags);
@@ -592,12 +571,11 @@ public:
      */
     sqe_awaitable linkat(
         int olddirfd,
-        const char *oldpath,
+        const char* oldpath,
         int newdirfd,
-        const char *newpath,
+        const char* newpath,
         int flags,
-        uint8_t iflags = 0
-    ) {
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_linkat(sqe, olddirfd, oldpath, newdirfd, newpath, flags);
         return await_work(sqe, iflags);
@@ -611,41 +589,39 @@ public:
      */
     sqe_awaitable unlinkat(
         int dfd,
-        const char *path,
+        const char* path,
         unsigned flags,
-        uint8_t iflags = 0
-    ) {
+        uint8_t iflags = 0) {
         auto* sqe = io_uring_get_sqe_safe();
         io_uring_prep_unlinkat(sqe, dfd, path, flags);
         return await_work(sqe, iflags);
     }
 
-private:
-    sqe_awaitable await_work(
-        io_uring_sqe* sqe,
-        uint8_t iflags
-    ) noexcept {
+   private:
+    sqe_awaitable await_work(io_uring_sqe* sqe, uint8_t iflags) noexcept {
         io_uring_sqe_set_flags(sqe, iflags);
         return sqe_awaitable(sqe);
     }
 
-public:
+   public:
     /** Get a sqe pointer that can never be NULL
      * @param ring pointer to inited io_uring struct
      * @return pointer to `io_uring_sqe` struct (not NULL)
      */
-    [[nodiscard]]
-    io_uring_sqe* io_uring_get_sqe_safe() noexcept {
+    [[nodiscard]] io_uring_sqe* io_uring_get_sqe_safe() noexcept {
         auto* sqe = io_uring_get_sqe(&ring);
         if (__builtin_expect(!!sqe, true)) {
             return sqe;
         } else {
-            printf_if_verbose(__FILE__ ": SQ is full, flushing %u cqe(s)\n", cqe_count);
+            printf_if_verbose(
+                __FILE__ ": SQ is full, flushing %u cqe(s)\n",
+                cqe_count);
             io_uring_cq_advance(&ring, cqe_count);
             cqe_count = 0;
             io_uring_submit(&ring);
             sqe = io_uring_get_sqe(&ring);
-            if (__builtin_expect(!!sqe, true)) return sqe;
+            if (__builtin_expect(!!sqe, true))
+                return sqe;
             panic("io_uring_get_sqe", ENOMEM);
         }
     }
@@ -653,23 +629,27 @@ public:
     /** Wait for an event forever, blocking
      * @see io_uring_wait_cqe
      * @see io_uring_enter(2)
-     * @return a pair of promise pointer (used for resuming suspended coroutine) and retcode of finished command
+     * @return a pair of promise pointer (used for resuming suspended coroutine)
+     * and retcode of finished command
      */
     template <typename T, bool nothrow>
     T run(const task<T, nothrow>& t) noexcept(nothrow) {
         while (!t.done()) {
             io_uring_submit_and_wait(&ring, 1);
 
-            io_uring_cqe *cqe;
+            io_uring_cqe* cqe;
             unsigned head;
 
             io_uring_for_each_cqe(&ring, head, cqe) {
                 ++cqe_count;
-                auto coro = static_cast<resolver *>(io_uring_cqe_get_data(cqe));
-                if (coro) coro->resolve(cqe->res);
+                auto coro = static_cast<resolver*>(io_uring_cqe_get_data(cqe));
+                if (coro)
+                    coro->resolve(cqe->res);
             }
 
-            printf_if_verbose(__FILE__ ": Found %u cqe(s), looping...\n", cqe_count);
+            printf_if_verbose(
+                __FILE__ ": Found %u cqe(s), looping...\n",
+                cqe_count);
 
             io_uring_cq_advance(&ring, cqe_count);
             cqe_count = 0;
@@ -678,7 +658,7 @@ public:
         return t.get_result();
     }
 
-public:
+   public:
     /** Register files for I/O
      * @param fds fds to register
      * @see io_uring_register(2) IORING_REGISTER_FILES
@@ -686,35 +666,36 @@ public:
     void register_files(std::initializer_list<int> fds) {
         register_files(fds.begin(), (unsigned int)fds.size());
     }
-    void register_files(const int *files, unsigned int nr_files) {
-        io_uring_register_files(&ring, files, nr_files) | panic_on_err("io_uring_register_files", false);
+    void register_files(const int* files, unsigned int nr_files) {
+        io_uring_register_files(&ring, files, nr_files)
+            | panic_on_err("io_uring_register_files", false);
     }
 
     /** Update registered files
      * @see io_uring_register(2) IORING_REGISTER_FILES_UPDATE
      */
-    void register_files_update(unsigned off, int *files, unsigned nr_files) {
-        io_uring_register_files_update(&ring, off, files, nr_files) | panic_on_err("io_uring_register_files", false);
+    void register_files_update(unsigned off, int* files, unsigned nr_files) {
+        io_uring_register_files_update(&ring, off, files, nr_files)
+            | panic_on_err("io_uring_register_files", false);
     }
 
     /** Unregister all files
      * @see io_uring_register(2) IORING_UNREGISTER_FILES
      */
-    int unregister_files() noexcept {
-        return io_uring_unregister_files(&ring);
-    }
+    int unregister_files() noexcept { return io_uring_unregister_files(&ring); }
 
-public:
+   public:
     /** Register buffers for I/O
      * @param ioves array of iovec to register
      * @see io_uring_register(2) IORING_REGISTER_BUFFERS
      */
     template <unsigned int N>
-    void register_buffers(iovec (&&ioves) [N]) {
+    void register_buffers(iovec(&&ioves)[N]) {
         register_buffers(&ioves[0], N);
     }
-    void register_buffers(const struct iovec *iovecs, unsigned nr_iovecs) {
-        io_uring_register_buffers(&ring, iovecs, nr_iovecs) | panic_on_err("io_uring_register_buffers", false);
+    void register_buffers(const struct iovec* iovecs, unsigned nr_iovecs) {
+        io_uring_register_buffers(&ring, iovecs, nr_iovecs)
+            | panic_on_err("io_uring_register_buffers", false);
     }
 
     /** Unregister all buffers
@@ -724,14 +705,11 @@ public:
         return io_uring_unregister_buffers(&ring);
     }
 
-public:
+   public:
     /** Return internal io_uring handle */
-    [[nodiscard]]
-    io_uring& get_handle() noexcept {
-        return ring;
-    }
+    [[nodiscard]] io_uring& get_handle() noexcept { return ring; }
 
-private:
+   private:
     io_uring ring;
     unsigned cqe_count = 0;
     bool probe_ops[IORING_OP_LAST] = {};

--- a/include/liburing/sqe_awaitable.hpp
+++ b/include/liburing/sqe_awaitable.hpp
@@ -13,7 +13,7 @@ struct resolver {
     virtual void resolve(int result) noexcept = 0;
 };
 
-struct resume_resolver final: resolver {
+struct resume_resolver final : resolver {
     friend struct sqe_awaitable;
 
     void resolve(int result) noexcept override {
@@ -21,48 +21,49 @@ struct resume_resolver final: resolver {
         handle.resume();
     }
 
-private:
+   private:
     std::coroutine_handle<> handle;
     int result = 0;
 };
 static_assert(std::is_trivially_destructible_v<resume_resolver>);
 
-struct deferred_resolver final: resolver {
-    void resolve(int result) noexcept override {
-        this->result = result;
-    }
+struct deferred_resolver final : resolver {
+    void resolve(int result) noexcept override { this->result = result; }
 
 #ifndef NDEBUG
     ~deferred_resolver() {
-        assert(!!result && "deferred_resolver is destructed before it's resolved");
+        assert(
+            !!result && "deferred_resolver is destructed before it's resolved");
     }
 #endif
 
     std::optional<int> result;
 };
 
-struct callback_resolver final: resolver {
-    callback_resolver(std::function<void (int result)>&& cb): cb(std::move(cb)) {}
+struct callback_resolver final : resolver {
+    callback_resolver(std::function<void(int result)>&& cb)
+      : cb(std::move(cb)) {}
 
     void resolve(int result) noexcept override {
         this->cb(result);
         delete this;
     }
 
-private:
-    std::function<void (int result)> cb;
+   private:
+    std::function<void(int result)> cb;
 };
 
 struct sqe_awaitable {
     // TODO: use cancel_token to implement cancellation
-    sqe_awaitable(io_uring_sqe* sqe) noexcept: sqe(sqe) {}
+    sqe_awaitable(io_uring_sqe* sqe) noexcept
+      : sqe(sqe) {}
 
     // User MUST keep resolver alive before the operation is finished
     void set_deferred(deferred_resolver& resolver) {
         io_uring_sqe_set_data(sqe, &resolver);
     }
 
-    void set_callback(std::function<void (int result)> cb) {
+    void set_callback(std::function<void(int result)> cb) {
         io_uring_sqe_set_data(sqe, new callback_resolver(std::move(cb)));
     }
 
@@ -71,7 +72,8 @@ struct sqe_awaitable {
             resume_resolver resolver {};
             io_uring_sqe* sqe;
 
-            await_sqe(io_uring_sqe* sqe): sqe(sqe) {}
+            await_sqe(io_uring_sqe* sqe)
+              : sqe(sqe) {}
 
             constexpr bool await_ready() const noexcept { return false; }
 
@@ -80,13 +82,15 @@ struct sqe_awaitable {
                 io_uring_sqe_set_data(sqe, &resolver);
             }
 
-            constexpr int await_resume() const noexcept { return resolver.result; }
+            constexpr int await_resume() const noexcept {
+                return resolver.result;
+            }
         };
 
         return await_sqe(sqe);
     }
 
-private:
+   private:
     io_uring_sqe* sqe;
 };
 

--- a/include/liburing/stdlib_coroutine.hpp
+++ b/include/liburing/stdlib_coroutine.hpp
@@ -3,26 +3,26 @@
 
 // This needs to be defined to enable the <coroutine> header in libstdc++ when
 // using clang
-#   if defined(__clang__) && !defined(__cpp_impl_coroutine)
-#      define __cpp_impl_coroutine 201902L
-#   endif
+#    if defined(__clang__) && !defined(__cpp_impl_coroutine)
+#        define __cpp_impl_coroutine 201902L
+#    endif
 
-#   include <coroutine>
+#    include <coroutine>
 
 // std::coroutine_handle and std::coroutine_traits need to be included in
 // std::experimental when using libstdc++ and clang together, however the others
 // don't.
-#   ifdef __clang__
+#    ifdef __clang__
 namespace std::experimental {
 using std::coroutine_handle;
 using std::coroutine_traits;
 } // namespace std::experimental
-#   endif
+#    endif
 
 // If we have the include <experimental/coroutine>, then we need to ensure that
 // std::experimental::* are inside namespace std
 #elif __has_include(<experimental/coroutine>)
-#   include <experimental/coroutine>
+#    include <experimental/coroutine>
 namespace std {
 using std::experimental::coroutine_handle;
 using std::experimental::coroutine_traits;

--- a/include/liburing/task.hpp
+++ b/include/liburing/task.hpp
@@ -17,17 +17,20 @@ struct task_promise_base {
     task<T, nothrow> get_return_object();
     auto initial_suspend() { return std::suspend_never(); }
     auto final_suspend() noexcept {
-        struct Awaiter: std::suspend_always {
-            task_promise_base *me_;
+        struct Awaiter : std::suspend_always {
+            task_promise_base* me_;
 
-            Awaiter(task_promise_base *me): me_(me) {};
-            std::coroutine_handle<> await_suspend(std::coroutine_handle<> caller) const noexcept {
+            Awaiter(task_promise_base* me)
+              : me_(me) {};
+            std::coroutine_handle<> await_suspend(
+                std::coroutine_handle<> caller) const noexcept {
                 if (__builtin_expect(me_->result_.index() == 3, false)) {
                     // FIXME: destroy current coroutine; otherwise memory leaks.
                     if (me_->waiter_) {
                         me_->waiter_.destroy();
                     }
-                    std::coroutine_handle<task_promise_base>::from_promise(*me_).destroy();
+                    std::coroutine_handle<task_promise_base>::from_promise(*me_)
+                        .destroy();
                 } else if (me_->waiter_) {
                     return me_->waiter_;
                 }
@@ -38,14 +41,15 @@ struct task_promise_base {
     }
     void unhandled_exception() {
         if constexpr (!nothrow) {
-            if (__builtin_expect(result_.index() == 3, false)) return;
+            if (__builtin_expect(result_.index() == 3, false))
+                return;
             result_.template emplace<2>(std::current_exception());
         } else {
             __builtin_unreachable();
         }
     }
 
-protected:
+   protected:
     friend struct task<T, nothrow>;
     task_promise_base() = default;
     std::coroutine_handle<> waiter_;
@@ -54,31 +58,35 @@ protected:
         std::conditional_t<std::is_void_v<T>, std::monostate, T>,
         std::conditional_t<!nothrow, std::exception_ptr, std::monostate>,
         std::monostate // indicates that the promise is detached
-    > result_;
+        >
+        result_;
 };
 
 // only for internal usage
 template <typename T, bool nothrow>
-struct task_promise final: task_promise_base<T, nothrow> {
+struct task_promise final : task_promise_base<T, nothrow> {
     using task_promise_base<T, nothrow>::result_;
 
     template <typename U>
     void return_value(U&& u) {
-        if (__builtin_expect(result_.index() == 3, false)) return;
+        if (__builtin_expect(result_.index() == 3, false))
+            return;
         result_.template emplace<1>(static_cast<U&&>(u));
     }
     void return_value(int u) {
-        if (__builtin_expect(result_.index() == 3, false)) return;
+        if (__builtin_expect(result_.index() == 3, false))
+            return;
         result_.template emplace<1>(u);
     }
 };
 
 template <bool nothrow>
-struct task_promise<void, nothrow> final: task_promise_base<void, nothrow> {
+struct task_promise<void, nothrow> final : task_promise_base<void, nothrow> {
     using task_promise_base<void, nothrow>::result_;
 
     void return_void() {
-        if (__builtin_expect(result_.index() == 3, false)) return;
+        if (__builtin_expect(result_.index() == 3, false))
+            return;
         result_.template emplace<1>(std::monostate {});
     }
 };
@@ -86,8 +94,10 @@ struct task_promise<void, nothrow> final: task_promise_base<void, nothrow> {
 /**
  * An awaitable object that returned by an async function
  * @tparam T value type holded by this task
- * @tparam nothrow if true, the coroutine assigned by this task won't throw exceptions ( slightly better performance )
- * @warning do NOT discard this object when returned by some function, or UB WILL happen
+ * @tparam nothrow if true, the coroutine assigned by this task won't throw
+ * exceptions ( slightly better performance )
+ * @warning do NOT discard this object when returned by some function, or UB
+ * WILL happen
  */
 template <typename T = void, bool nothrow = false>
 struct task final {
@@ -95,7 +105,7 @@ struct task final {
     using handle_t = std::coroutine_handle<promise_type>;
 
     task(const task&) = delete;
-    task& operator =(const task&) = delete;
+    task& operator=(const task&) = delete;
 
     bool await_ready() {
         auto& result_ = coro_.promise().result_;
@@ -103,13 +113,12 @@ struct task final {
     }
 
     template <typename T_, bool nothrow_>
-    void await_suspend(std::coroutine_handle<task_promise<T_, nothrow_>> caller) noexcept {
+    void await_suspend(
+        std::coroutine_handle<task_promise<T_, nothrow_>> caller) noexcept {
         coro_.promise().waiter_ = caller;
     }
 
-    T await_resume() const {
-        return get_result();
-    }
+    T await_resume() const { return get_result(); }
 
     /** Get the result hold by this task */
     T get_result() const {
@@ -126,42 +135,42 @@ struct task final {
     }
 
     /** Get is the coroutine done */
-    bool done() const {
-        return coro_.done();
-    }
+    bool done() const { return coro_.done(); }
 
     /** Only for placeholder */
-    task(): coro_(nullptr) {};
+    task()
+      : coro_(nullptr) {};
 
-    task(task&& other) noexcept {
-        coro_ = std::exchange(other.coro_, nullptr);
-    }
+    task(task&& other) noexcept { coro_ = std::exchange(other.coro_, nullptr); }
 
-    task& operator =(task&& other) noexcept {
-        if (coro_) coro_.destroy();
+    task& operator=(task&& other) noexcept {
+        if (coro_)
+            coro_.destroy();
         coro_ = std::exchange(other.coro_, nullptr);
         return *this;
     }
 
     /** Destroy (when done) or detach (when not done) the task object */
     ~task() {
-        if (!coro_) return;
+        if (!coro_)
+            return;
         if (!coro_.done()) {
-            coro_.promise().result_.template emplace<3>(std::monostate{});
+            coro_.promise().result_.template emplace<3>(std::monostate {});
         } else {
             coro_.destroy();
         }
     }
 
-private:
+   private:
     friend struct task_promise_base<T, nothrow>;
-    task(promise_type *p): coro_(handle_t::from_promise(*p)) {}
+    task(promise_type* p)
+      : coro_(handle_t::from_promise(*p)) {}
     handle_t coro_;
 };
 
 template <typename T, bool nothrow>
 task<T, nothrow> task_promise_base<T, nothrow>::get_return_object() {
-    return task<T, nothrow>(static_cast<task_promise<T, nothrow> *>(this));
+    return task<T, nothrow>(static_cast<task_promise<T, nothrow>*>(this));
 }
 
 } // namespace uio

--- a/include/liburing/utils.hpp
+++ b/include/liburing/utils.hpp
@@ -6,12 +6,12 @@
 
 namespace uio {
 /** Fill an iovec struct using buf & size */
-constexpr inline iovec to_iov(void *buf, size_t size) noexcept {
-    return { buf, size };
+constexpr inline iovec to_iov(void* buf, size_t size) noexcept {
+    return {buf, size};
 }
 /** Fill an iovec struct using string view */
 constexpr inline iovec to_iov(std::string_view sv) noexcept {
-    return to_iov(const_cast<char *>(sv.data()), sv.size());
+    return to_iov(const_cast<char*>(sv.data()), sv.size());
 }
 /** Fill an iovec struct using std::array */
 template <size_t N>
@@ -21,29 +21,29 @@ constexpr inline iovec to_iov(std::array<char, N>& array) noexcept {
 
 template <typename Fn>
 struct on_scope_exit {
-    on_scope_exit(Fn &&fn): _fn(std::move(fn)) {}
+    on_scope_exit(Fn&& fn)
+      : _fn(std::move(fn)) {}
     ~on_scope_exit() { this->_fn(); }
 
-private:
+   private:
     Fn _fn;
 };
 
-[[nodiscard]]
-constexpr inline __kernel_timespec dur2ts(std::chrono::nanoseconds dur) noexcept {
+[[nodiscard]] constexpr inline __kernel_timespec dur2ts(
+    std::chrono::nanoseconds dur) noexcept {
     auto secs = std::chrono::duration_cast<std::chrono::seconds>(dur);
     dur -= secs;
-    return { secs.count(), dur.count() };
+    return {secs.count(), dur.count()};
 }
 
 /** Convert errno to exception
  * @throw std::runtime_error / std::system_error
  * @return never
  */
-[[noreturn]]
-void panic(std::string_view sv, int err) {
+[[noreturn]] void panic(std::string_view sv, int err) {
 #ifndef NDEBUG
     // https://stackoverflow.com/questions/77005/how-to-automatically-generate-a-stacktrace-when-my-program-crashes
-    void *array[32];
+    void* array[32];
     size_t size;
 
     // get void*'s for all entries on the stack
@@ -61,28 +61,29 @@ void panic(std::string_view sv, int err) {
 
 struct panic_on_err {
     panic_on_err(std::string_view _command, bool _use_errno)
-        : command(_command)
-        , use_errno(_use_errno) {}
+      : command(_command)
+      , use_errno(_use_errno) {}
     std::string_view command;
     bool use_errno;
 };
 
-inline int operator |(int ret, panic_on_err&& poe) {
+inline int operator|(int ret, panic_on_err&& poe) {
     if (ret < 0) {
         if (poe.use_errno) {
             panic(poe.command, errno);
         } else {
-            if (ret != -ETIME) panic(poe.command, -ret);
+            if (ret != -ETIME)
+                panic(poe.command, -ret);
         }
     }
     return ret;
 }
 template <bool nothrow>
-inline task<int> operator |(task<int, nothrow> tret, panic_on_err&& poe) {
-    co_return (co_await tret) | std::move(poe);
+inline task<int> operator|(task<int, nothrow> tret, panic_on_err&& poe) {
+    co_return(co_await tret) | std::move(poe);
 }
-inline task<int> operator |(sqe_awaitable tret, panic_on_err&& poe) {
-    co_return (co_await tret) | std::move(poe);
+inline task<int> operator|(sqe_awaitable tret, panic_on_err&& poe) {
+    co_return(co_await tret) | std::move(poe);
 }
 
 } // namespace uio

--- a/tests/delay_and_print.cpp
+++ b/tests/delay_and_print.cpp
@@ -4,18 +4,22 @@
 #include <liburing/io_service.hpp>
 
 int main() {
-    using uio::io_service;
-    using uio::task;
-    using uio::panic_on_err;
     using uio::dur2ts;
+    using uio::io_service;
+    using uio::panic_on_err;
+    using uio::task;
 
     io_service service;
 
-    service.run([] (io_service& service) -> task<> {
-        auto delayAndPrint = [&] (int second, uint8_t iflags = 0) -> task<> {
+    service.run([](io_service& service) -> task<> {
+        auto delayAndPrint = [&](int second, uint8_t iflags = 0) -> task<> {
             auto ts = dur2ts(std::chrono::seconds(second));
-            co_await service.timeout(&ts, iflags) | panic_on_err("timeout", false);
-            fmt::print("{:%T}: delayed {}s\n", std::chrono::system_clock::now().time_since_epoch(), second);
+            co_await service.timeout(&ts, iflags)
+                | panic_on_err("timeout", false);
+            fmt::print(
+                "{:%T}: delayed {}s\n",
+                std::chrono::system_clock::now().time_since_epoch(),
+                second);
         };
 
         fmt::print("in sequence start\n");

--- a/tests/ping_pong.cpp
+++ b/tests/ping_pong.cpp
@@ -10,9 +10,11 @@ auto ping(uio::io_service& service, int read_fd, int write_fd) -> uio::task<> {
     std::array<char, 64> buffer;
 
     for (int i = 0; i < 20; i++) {
-        int count =
-            co_await service.read(read_fd, buffer.data(), buffer.size(), 0)
-            | uio::panic_on_err("ping: Unable to read from read_fd", false);
+        int count = co_await service
+                        .read(read_fd, buffer.data(), buffer.size(), 0)
+                  | uio::panic_on_err(
+                        "ping: Unable to read from read_fd",
+                        false);
 
         auto recieved = std::string_view(buffer.data(), count);
 
@@ -31,7 +33,7 @@ auto ping(uio::io_service& service, int read_fd, int write_fd) -> uio::task<> {
         | uio::panic_on_err("ping: Unable to close write_fd", false);
 
     // Check for EOF before exiting
-    if(0 != co_await service.read(read_fd, buffer.data(), buffer.size(), 0)) {
+    if (0 != co_await service.read(read_fd, buffer.data(), buffer.size(), 0)) {
         throw std::runtime_error("pong: Pipe not at EOF like expected");
     }
 
@@ -48,9 +50,11 @@ auto pong(uio::io_service& service, int read_fd, int write_fd) -> uio::task<> {
         co_await service.write(write_fd, msg.data(), msg.size(), 0)
             | uio::panic_on_err("pong: Unable to write to write_fd", false);
 
-        int count =
-            co_await service.read(read_fd, buffer.data(), buffer.size(), 0)
-            | uio::panic_on_err("pong: Unable to read from read_fd", false);
+        int count = co_await service
+                        .read(read_fd, buffer.data(), buffer.size(), 0)
+                  | uio::panic_on_err(
+                        "pong: Unable to read from read_fd",
+                        false);
 
         auto recieved = std::string_view(buffer.data(), count);
 
@@ -66,7 +70,7 @@ auto pong(uio::io_service& service, int read_fd, int write_fd) -> uio::task<> {
         | uio::panic_on_err("pong: Unable to close write_fd", false);
 
     // Check for EOF before exiting
-    if(0 != co_await service.read(read_fd, buffer.data(), buffer.size(), 0)) {
+    if (0 != co_await service.read(read_fd, buffer.data(), buffer.size(), 0)) {
         throw std::runtime_error("pong: Pipe not at EOF like expected");
     }
 


### PR DESCRIPTION
This commit adds a .clang-format to the project, and formats code files according to the specification outlined in the .clang-format. This helps to make the code more readable, and to make things more consistent.

In VSCode, any code file can be formatted with Ctrl+Shift+I, and it'll automatically be formatted according to the clang-format if you have that set as your formatter! (I believe this is the default setting for the microsoft C/C++ extension, and also for the related ccls Language Server!)

If you don't like this formatting style, I'm definitely open to changing it! You can download this branch, play around with the settings in the .clang-format, and see what you'd prefer! Clang-format 12 is recommended, as that's the one that's most up to date with modern C++ features. See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html. 

You can also format things on the command line, via:
```zsh
clang-format -i <files...>
```
The -i specifier tells it to format the file in-place. If you don't pass it, it will print the formatted file to standard output. I formatted all the files in the repository with:
```zsh
clang-format -i (demo|include|tests)/**/*.(hpp|cpp)
```
Note that this uses zsh's extended GLOB syntax, so you'll need to run it in a zsh shell. To see which files it'd change, you can run `ls (demo|include|tests)/**/*.(hpp|cpp)`.