### PR TITLE
README: make the demo code compilable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ Tested: `Ubuntu 5.9.0-050900rc6daily20200923-generic #202009222208 SMP Wed Sep 2
 ```cpp
 #include <liburing/io_service.hpp>
 
+using namespace std::literals;
+
 int main() {
     // You first need an io_service instance
-    io_service service;
+    uio::io_service service;
 
     // In order to `co_await`, you must be in a coroutine.
     // We use IIFE here for simplification
-    auto work = [&] () -> task<> {
+    auto work = [&] () -> uio::task<> {
         // Use Linux syscalls just as what you did before (except a little changes)
         const auto str = "Hello world\n"sv;
         co_await service.write(STDOUT_FILENO, str.data(), str.size(), 0);


### PR DESCRIPTION
Before these changes, the example code in `README.md` would not compile (at least on Fedora 40, gcc 14.1), mainly because of namespace issues.

After these changes, copying the demo code from `README.md` in a file named `readme_demo.cpp` and executing the following commands works reliably:

```
# dnf install -y liburing-devel
# g++ -Iinclude -std=c++20 -luring -o readme_demo readme_demo.cpp
# ./readme_demo
Hello world
```